### PR TITLE
Add AVR and RISCV targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ COPY llvm-fix-libxml2-dep.patch ./
 RUN patch -p0 -i llvm-fix-libxml2-dep.patch
 RUN mkdir -p /deps/llvm-7.0.0.src/build
 WORKDIR /deps/llvm-7.0.0.src/build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=/deps/local -DCMAKE_PREFIX_PATH=/deps/local -DCMAKE_BUILD_TYPE=Release -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=/deps/local -DCMAKE_PREFIX_PATH=/deps/local -DCMAKE_BUILD_TYPE=Release -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="WebAssembly;AVR;RISCV"
 RUN make $MAKE_JOBS install
 
 # clang


### PR DESCRIPTION
Just like WebAssembly, RISC-V is also possibly going to be a standard target.RISCV is the next big thing so it is good to have support (even if preliminary). I am contemplating buying [hifive](https://www.crowdsupply.com/sifive/hifive1) boards/IC to test this on real hardware. On the linux end, there is good support in qemu which can be used for basic testing if nothing else.

AVR is a great way for getting all arduino people to use zig. As I reported in ziglang/zig#1373
lld has very little AVR support (no -m option yet)  but my preliminary testing with build-obj gave .o files which can then be linked by avr-ld. I will send the necessary zig patches once you pull this.
 
I didn't test this (I don't do docker) but it looks too obvious to cause any other issue.