### PR TITLE
Remove explicit enabling of AVR backend as its no longer experimental

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/l
 RUN tar xf llvm-11.0.0.src.tar.xz
 RUN mkdir -p /deps/llvm-11.0.0.src/build
 WORKDIR /deps/llvm-11.0.0.src/build
-RUN cmake .. -DCMAKE_INSTALL_PREFIX=/deps/local -DCMAKE_PREFIX_PATH=/deps/local -DCMAKE_BUILD_TYPE=Release -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="AVR" -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_ENABLE_TERMINFO=OFF -G Ninja
+RUN cmake .. -DCMAKE_INSTALL_PREFIX=/deps/local -DCMAKE_PREFIX_PATH=/deps/local -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_LIBXML2=OFF -DLLVM_ENABLE_TERMINFO=OFF -G Ninja
 RUN ninja install
 
 # lld


### PR DESCRIPTION
AVR got stabilized in LLVM 11.