### PR TITLE
Run zig without specifying a path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,3 +20,4 @@ RUN apk --no-cache add \
     git \
     cmake
 COPY --from=builder /deps/local/ /deps/local/
+ENV PATH $PATH:/deps/local/bin


### PR DESCRIPTION
Hi,

This PR adds the bin directory to the PATH environment variable to run zig without specifying a path.